### PR TITLE
Fix: JSONDocument's content not initalizable

### DIFF
--- a/src/main/java/it/iisvittorioveneto/lit/database/JSONArrayDocument.java
+++ b/src/main/java/it/iisvittorioveneto/lit/database/JSONArrayDocument.java
@@ -1,0 +1,2 @@
+package it.iisvittorioveneto.lit.database;public class JSONArrayDocument {
+}

--- a/src/main/java/it/iisvittorioveneto/lit/database/JSONObjectDocument.java
+++ b/src/main/java/it/iisvittorioveneto/lit/database/JSONObjectDocument.java
@@ -1,0 +1,2 @@
+package it.iisvittorioveneto.lit.database;public class JSONObjectDocument {
+}

--- a/src/main/java/it/iisvittorioveneto/lit/database/JSONType.java
+++ b/src/main/java/it/iisvittorioveneto/lit/database/JSONType.java
@@ -1,6 +1,0 @@
-package it.iisvittorioveneto.lit.database;
-
-public enum JSONType {
-    JSONObject,
-    JSONArray
-}

--- a/src/main/java/it/iisvittorioveneto/lit/database/utils/JSONArray.java
+++ b/src/main/java/it/iisvittorioveneto/lit/database/utils/JSONArray.java
@@ -1,0 +1,2 @@
+package it.iisvittorioveneto.lit.database.utils;public class JSONArray {
+}

--- a/src/main/java/it/iisvittorioveneto/lit/database/utils/JSONContent.java
+++ b/src/main/java/it/iisvittorioveneto/lit/database/utils/JSONContent.java
@@ -1,0 +1,2 @@
+package it.iisvittorioveneto.lit.database.utils;public class JSONContent {
+}

--- a/src/main/java/it/iisvittorioveneto/lit/database/utils/JSONObject.java
+++ b/src/main/java/it/iisvittorioveneto/lit/database/utils/JSONObject.java
@@ -1,0 +1,2 @@
+package it.iisvittorioveneto.lit.database.utils;public class JSONObject {
+}


### PR DESCRIPTION
Generated a new class structure to use polymorphism to fix the problem.

![JSONDocumentSchema](https://user-images.githubusercontent.com/42815033/172044844-c8d59ce4-3135-4ec9-88d9-6577626b69a8.jpeg)

